### PR TITLE
Fix net::ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION error

### DIFF
--- a/src/http/api/routes/file/download.js
+++ b/src/http/api/routes/file/download.js
@@ -49,7 +49,7 @@ module.exports.handler = async (req, reply) => {
     const resHeaders = {
         'Content-Length': file.size,
         'Accept-Ranges': 'bytes',
-        'Content-Disposition': `attachment; filename=${encodeURI(file.name)}`,
+        'Content-Disposition': `attachment; filename="${encodeURI(file.name)}"`,
     }
     const mimeType = mime.lookup(path.extname(file.name))
     if (mimeType) resHeaders['Content-Type'] = mimeType


### PR DESCRIPTION
When the filename contains a comma, the above error error occurs when trying to download a file. The solution is to enclose the filename in quotes.